### PR TITLE
fix icon names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
         <img src="./Banner.png" />
     </a>
 <p align="centre"> 
-<a href="https://twitter.com/br_blacky"> <img width="30px" src="https://raw.githubusercontent.com/brblacky/BrBlacky/main/icons8-twitter-100.png" title="Telegram"/></a>
-<a href="https://youtube.com/c/brblacky"> <img width="30px" src="https://raw.githubusercontent.com/brblacky/BrBlacky/main/icons8-youtube-music-500.png" title="Telegram"/></a>
+<a href="https://twitter.com/br_blacky"> <img width="30px" src="https://raw.githubusercontent.com/brblacky/BrBlacky/main/icons8-twitter-100.png" title="Twitter"/></a>
+<a href="https://youtube.com/c/brblacky"> <img width="30px" src="https://raw.githubusercontent.com/brblacky/BrBlacky/main/icons8-youtube-music-500.png" title="YouTube"/></a>
 <a href="https://t.me/sdip521"> <img width="30px" src="https://github.com/brblacky/BrBlacky/blob/main/icons8-telegram-app-500.png" title="Telegram"/></a>
-<a href="https://blacky-dev.cf/"> <img width="30px" src="https://github.com/brblacky/BrBlacky/blob/main/icons8-website-100.png" title="Telegram"/></a>
+<a href="https://blacky-dev.cf/"> <img width="30px" src="https://github.com/brblacky/BrBlacky/blob/main/icons8-website-100.png" title="Website"/></a>
 <a href="mailto: sdipedit@gmail.com"> <img width="30px" src="https://github.com/brblacky/BrBlacky/blob/main/icons8-email-100.png" title="Email"/> </a><br>
 </p>
 


### PR DESCRIPTION
When hovered some of the third party icons (Twitter, YouTube and Website) they were shown as "Telegram".